### PR TITLE
Fix(import): preserve HTML in email footer text on import

### DIFF
--- a/includes/Importers/AbstractImporter.php
+++ b/includes/Importers/AbstractImporter.php
@@ -57,6 +57,20 @@ abstract class AbstractImporter
         }
     }
 
+    /**
+     * Option names whose values may contain WooCommerce-permitted HTML and must be
+     * sanitized with wp_kses_post() instead of sanitize_text_field() on import.
+     *
+     * Base returns an empty array so every existing importer keeps its current
+     * behavior. Subclasses override to opt specific fields in.
+     *
+     * @return string[]
+     */
+    protected function get_rich_text_option_names(): array
+    {
+        return [];
+    }
+
     protected function import_option($data)
     {
         // Canonical keys (v1.2.0+) with legacy 'option'/'value' fallback for v1.1.9 archives.
@@ -68,14 +82,18 @@ abstract class AbstractImporter
             $option_value = maybe_unserialize($option_value);
         }
 
-        // If option value is an array, sanitize each value
-        if (is_array($option_value)) {
-            array_walk_recursive($option_value, function (&$value) {
-                $value = sanitize_text_field($value);
-            });
+        // Rich-text options (e.g. WooCommerce email footer) keep the HTML that
+        // WooCommerce itself permits; everything else is stripped to plain text.
+        if ( in_array( $option_name, $this->get_rich_text_option_names(), true ) ) {
+            $option_value = wp_kses_post( (string) $option_value );
+        } elseif ( is_array( $option_value ) ) {
+            // If option value is an array, sanitize each value
+            array_walk_recursive( $option_value, function ( &$value ) {
+                $value = sanitize_text_field( $value );
+            } );
         } else {
             // If option value is a string, sanitize it
-            $option_value = sanitize_text_field($option_value);
+            $option_value = sanitize_text_field( $option_value );
         }
 
         $allowed_option_data  = $this->exporter->get_data();

--- a/includes/Importers/WooCommerce/EmailsOptionsImporter.php
+++ b/includes/Importers/WooCommerce/EmailsOptionsImporter.php
@@ -15,4 +15,14 @@ class EmailsOptionsImporter extends AbstractImporter {
 		parent::__construct( new EmailsOptionsExporter() );
 	}
 
+	/**
+	 * The email footer text may contain WooCommerce-permitted HTML, so it must be
+	 * sanitized with wp_kses_post() rather than stripped by sanitize_text_field().
+	 *
+	 * @return string[]
+	 */
+	protected function get_rich_text_option_names(): array {
+		return [ 'woocommerce_email_footer_text' ];
+	}
+
 }

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,7 @@ Post detailed information about the issue in the [support forum](http://wordpres
 * Fix: Unified option field names (option_name/option_value) across all exporters and importers.
 * Fix: Removed a duplicate entry in the email settings exporter.
 * Fix: Shipping method export is no longer limited to the three built-in types; all registered shipping methods are now exported. Unrecognized methods are reported on import.
+* Fix: HTML formatting in the WooCommerce email footer text is now preserved during Email Options import.
 
 = 1.1.9 =
 * WordPress 6.9 compatibility.


### PR DESCRIPTION
### Description:
The importer ran every scalar option value through `sanitize_text_field()`, which stripped all HTML tags. As a result, the WooCommerce email footer text (woocommerce_email_footer_text) lost its formatting during Email Options import, while plain text survived.

### Fix:
Added an overridable rich-text option allow-list to AbstractImporter (defaulting to empty, so no other importer changes behavior) and used `wp_kses_post()` for those options instead of `sanitize_text_field()`. EmailsOptionsImporter opts `woocommerce_email_footer_text` in, mirroring the sanitization WooCommerce itself applies to that field. The export was already correct and is unchanged.