### PR TITLE
Migrate block-based Local Pickup settings and locations

### DIFF
--- a/includes/Exporters/WooCommerce/ShippingZonesExporter.php
+++ b/includes/Exporters/WooCommerce/ShippingZonesExporter.php
@@ -92,6 +92,25 @@ class ShippingZonesExporter extends AbstractExporter {
             }
         }
 
+        // Block-based Local Pickup (WooCommerce → Settings → Shipping → Local Pickup)
+        // lives in two global options, not in the zone tables. Fold them into the same
+        // $options array so they travel with the Shipping Zones export. Names confirmed
+        // on WC 9.0.0 (see specs/013-local-pickup-investigation): the locations option is
+        // 'pickup_location_pickup_locations', not 'woocommerce_pickup_locations'.
+        $pickup_option_names = array(
+            'woocommerce_pickup_location_settings',
+            'pickup_location_pickup_locations',
+        );
+        foreach ( $pickup_option_names as $pickup_option_name ) {
+            $value = get_option( $pickup_option_name, null );
+            if ( null !== $value ) {
+                $options[] = array(
+                    'option_name'  => $pickup_option_name,
+                    'option_value' => maybe_serialize( $value ),
+                );
+            }
+        }
+
         $data = array(
             'woocommerce_shipping_zones'          => $zones,
             'woocommerce_shipping_zone_methods'     => $methods,

--- a/includes/Importers/WooCommerce/ShippingZonesImporter.php
+++ b/includes/Importers/WooCommerce/ShippingZonesImporter.php
@@ -117,14 +117,18 @@ class ShippingZonesImporter extends AbstractImporter {
 		$option_name  = sanitize_key( $data['option_name'] ?? $data['option'] ?? '' );
 		$option_value = $data['option_value'] ?? $data['value'] ?? '';
 
-		// Allowlist guard: this importer only ever writes per-instance shipping
-		// method settings, whose option names follow the WooCommerce pattern
-		// woocommerce_{method_id}_{instance_id}_settings. Reject anything else so
-		// a crafted import file cannot overwrite arbitrary options. (The parent's
-		// allowlist relies on the exporter querying the live DB, which does not
-		// apply here — the whole point is to import options that do not exist on
-		// the target site yet.)
-		if ( ! preg_match( '/^woocommerce_.+_\d+_settings$/', $option_name ) ) {
+		// Allowlist guard: permit per-instance shipping-method settings
+		// (woocommerce_{method_id}_{instance_id}_settings) PLUS the two global block
+		// Local Pickup options. Exact-name matching for the pickup options keeps the
+		// guard strict so a crafted import file cannot overwrite arbitrary options.
+		// Names confirmed on WC 9.0.0 (see specs/013-local-pickup-investigation):
+		// the locations option is 'pickup_location_pickup_locations'.
+		$allowed_pickup_options = array(
+			'woocommerce_pickup_location_settings',
+			'pickup_location_pickup_locations',
+		);
+		if ( ! in_array( $option_name, $allowed_pickup_options, true )
+			&& ! preg_match( '/^woocommerce_.+_\d+_settings$/', $option_name ) ) {
 			throw new \RuntimeException( "Invalid option name: $option_name" );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,7 @@ Post detailed information about the issue in the [support forum](http://wordpres
 * Fix: Unified option field names (option_name/option_value) across all exporters and importers.
 * Fix: Removed a duplicate entry in the email settings exporter.
 * Fix: Shipping method export is no longer limited to the three built-in types; all registered shipping methods are now exported. Unrecognized methods are reported on import.
+* Fix: Block-based Local Pickup settings and pickup locations now migrate with Shipping Zones export/import.
 
 = 1.1.9 =
 * WordPress 6.9 compatibility.


### PR DESCRIPTION
### Description:
Block-based Local Pickup (WooCommerce -> Settings -> Shipping -> Local Pickup) is a global feature stored in two wp_options rather than in the zone tables, so it was never captured by the Shipping Zones migration.

### Fix:
Exporter: fold woocommerce_pickup_location_settings and pickup_location_pickup_locations into the existing $options payload so they travel with the Shipping Zones export.

Importer: widen the allowlist guard in import_option() to accept those two exact names (strict in_array) alongside the per-instance settings regex. The existing unserialize -> recursive-sanitize -> update_option path and the validate() precondition are unchanged, keeping the guard strict against crafted option names.
